### PR TITLE
feat: metadata upload endpoint and queue trigger

### DIFF
--- a/e2e/adapters/worker.adapter.ts
+++ b/e2e/adapters/worker.adapter.ts
@@ -18,11 +18,15 @@ export class WorkerAdapter implements TestAdapter {
     // Kill any existing processes on the port
     await this.killExistingProcess(port);
 
-    // Set test environment variables for wrangler
+    // Set test environment variables for wrangler CLI process
     const env = { ...process.env, ...config.envVars };
+    const varArgs: string[] = [];
+    for (const [key, value] of Object.entries(config.envVars || {})) {
+      varArgs.push('--var', `${key}:${value}`);
+    }
 
-    // Spawn wrangler dev
-    this.devProcess = spawn('npx', ['wrangler', 'dev', '--port', port.toString(), '--var', 'NODE_ENV:test'], {
+    // Spawn wrangler dev with explicit Worker vars for the runtime
+    this.devProcess = spawn('npx', ['wrangler', 'dev', '--port', port.toString(), ...varArgs], {
       stdio: 'pipe',
       env,
       cwd: process.cwd(),

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -25,6 +25,7 @@ export const defaultConfig: Record<DeploymentTarget, Partial<E2EConfig>> = {
     port: 3001,
     envVars: {
       NODE_ENV: 'test',
+      CLEANUP_TOKEN: 'e2e-cleanup-token',
     },
   },
   worker: {
@@ -32,6 +33,7 @@ export const defaultConfig: Record<DeploymentTarget, Partial<E2EConfig>> = {
     port: 8787,
     envVars: {
       NODE_ENV: 'test',
+      CLEANUP_TOKEN: 'e2e-cleanup-token',
     },
   },
   docker: {
@@ -39,6 +41,7 @@ export const defaultConfig: Record<DeploymentTarget, Partial<E2EConfig>> = {
     port: 3000,
     envVars: {
       NODE_ENV: 'test',
+      CLEANUP_TOKEN: 'e2e-cleanup-token',
     },
   },
   production: {

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -67,9 +67,19 @@ export async function cleanupTestEnv(context: TestContext | undefined): Promise<
     return;
   }
 
+  const cleanupToken =
+    context.config.envVars?.CLEANUP_TOKEN || process.env.CLEANUP_TOKEN;
+
+  if (!cleanupToken) {
+    console.warn('Cleanup token not configured; skipping API cleanup requests');
+  }
+
   // Clean up storage data via API BEFORE terminating the server
   // This ensures the server is still running when we make cleanup API calls
   for (const prefix of context.cleanupPrefixes || []) {
+    if (!cleanupToken) {
+      break;
+    }
     try {
       // Parse prefix correctly: "project/version/" -> ["project", "version"]
       const trimmedPrefix = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
@@ -82,7 +92,7 @@ export async function cleanupTestEnv(context: TestContext | undefined): Promise<
         const response = await context.client(`/cleanup/${project}/${version}`, {
           method: 'DELETE',
           headers: {
-            'X-Test-Cleanup': 'true',
+            'X-Cleanup-Token': cleanupToken,
           },
         });
 

--- a/src/app.metadata.test.ts
+++ b/src/app.metadata.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { app, type AppEnv } from './app.js';
+import type { ApiKeyService } from './services/apikey/apikey.service.js';
+import type { FirestoreService } from './services/firestore/firestore.service.js';
+import type { StorageService } from './services/storage/storage.service.js';
+
+function createTestServer(options: {
+  storage: StorageService;
+  firestore?: FirestoreService;
+  queue?: { send: (payload: unknown) => Promise<void> };
+  apiKeyService?: ApiKeyService;
+}) {
+  const wrapper = new Hono<AppEnv>();
+  wrapper.use('*', async (c, next) => {
+    c.set('storage', options.storage);
+    if (options.firestore) c.set('firestore', options.firestore);
+    if (options.queue) c.set('queue', options.queue as unknown as Queue);
+    if (options.apiKeyService) c.set('apiKeyService', options.apiKeyService);
+    await next();
+  });
+  wrapper.route('/', app);
+  return wrapper;
+}
+
+function createFirestoreMock(overrides: Partial<FirestoreService> = {}): FirestoreService {
+  return {
+    createBuild: vi.fn() as any,
+    getBuild: vi.fn() as any,
+    getProjectBuilds: vi.fn() as any,
+    getBuildByVersion: vi.fn() as any,
+    getLatestBuild: vi.fn() as any,
+    updateBuild: vi.fn() as any,
+    updateBuildCoverage: vi.fn() as any,
+    updateProcessingStatus: vi.fn() as any,
+    archiveBuild: vi.fn() as any,
+    deleteBuild: vi.fn() as any,
+    ...overrides,
+  };
+}
+
+describe('app metadata route', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stores metadata ZIP at build-specific R2 key and publishes queue message', async () => {
+    const upload = vi.fn(async (key: string) => ({ url: `https://storage.test/${key}`, path: key }));
+    const send = vi.fn(async () => undefined);
+    const storage: StorageService = {
+      upload: upload as any,
+      getPresignedUploadUrl: vi.fn() as any,
+      deleteByPrefix: vi.fn() as any,
+    };
+
+    const firestore = createFirestoreMock({
+      getLatestBuild: vi.fn(async () => ({
+        id: 'build-123',
+        projectId: 'my-project',
+        versionId: 'v1.0.0',
+        buildNumber: 7,
+        zipUrl: 'https://storage.test/my-project/v1.0.0/storybook.zip',
+        status: 'active',
+        createdAt: new Date(),
+        createdBy: 'test',
+      })) as any,
+      updateProcessingStatus: vi.fn(async () => undefined) as any,
+    });
+
+    const server = createTestServer({
+      storage,
+      firestore,
+      queue: { send },
+    });
+
+    const res = await server.request('/upload/my-project/v1.0.0/metadata', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/zip' },
+      body: new Uint8Array([80, 75, 3, 4]),
+    });
+
+    expect(res.status).toBe(201);
+    expect(upload).toHaveBeenCalledWith(
+      'my-project/v1.0.0/builds/7/metadata-screenshots.zip',
+      expect.anything(),
+      'application/zip'
+    );
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'my-project',
+        versionId: 'v1.0.0',
+        buildId: 'build-123',
+        zipKey: 'my-project/v1.0.0/builds/7/metadata-screenshots.zip',
+        timestamp: expect.any(Number),
+      })
+    );
+    expect(firestore.updateProcessingStatus).toHaveBeenCalledWith('my-project', 'build-123', 'queued');
+
+    const body = await res.json();
+    expect(body.queued).toBe(true);
+    expect(body.buildNumber).toBe(7);
+  });
+
+  it('returns 400 when metadata ZIP body is empty', async () => {
+    const storage: StorageService = {
+      upload: vi.fn() as any,
+      getPresignedUploadUrl: vi.fn() as any,
+      deleteByPrefix: vi.fn() as any,
+    };
+    const firestore = createFirestoreMock();
+    const server = createTestServer({ storage, firestore });
+
+    const res = await server.request('/upload/my-project/v1.0.0/metadata', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/zip' },
+      body: new Uint8Array([]),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('No file provided');
+  });
+
+  it('returns 400 when no build exists for project/version', async () => {
+    const storage: StorageService = {
+      upload: vi.fn() as any,
+      getPresignedUploadUrl: vi.fn() as any,
+      deleteByPrefix: vi.fn() as any,
+    };
+    const firestore = createFirestoreMock({
+      getLatestBuild: vi.fn(async () => null) as any,
+    });
+    const server = createTestServer({ storage, firestore });
+
+    const res = await server.request('/upload/my-project/v1.0.0/metadata', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/zip' },
+      body: new Uint8Array([1, 2, 3]),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('Upload storybook.zip first');
+  });
+
+  it('works without queue binding and returns queued=false', async () => {
+    const upload = vi.fn(async (key: string) => ({ url: `https://storage.test/${key}`, path: key }));
+    const storage: StorageService = {
+      upload: upload as any,
+      getPresignedUploadUrl: vi.fn() as any,
+      deleteByPrefix: vi.fn() as any,
+    };
+    const firestore = createFirestoreMock({
+      getLatestBuild: vi.fn(async () => ({
+        id: 'build-123',
+        projectId: 'my-project',
+        versionId: 'v1.0.0',
+        buildNumber: 2,
+        zipUrl: 'https://storage.test/my-project/v1.0.0/storybook.zip',
+        status: 'active',
+        createdAt: new Date(),
+        createdBy: 'test',
+      })) as any,
+      updateProcessingStatus: vi.fn(async () => undefined) as any,
+    });
+    const server = createTestServer({ storage, firestore });
+
+    const res = await server.request('/upload/my-project/v1.0.0/metadata', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/zip' },
+      body: new Uint8Array([1, 2, 3]),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.queued).toBe(false);
+  });
+
+  it('requires auth when API key service is configured', async () => {
+    const storage: StorageService = {
+      upload: vi.fn() as any,
+      getPresignedUploadUrl: vi.fn() as any,
+      deleteByPrefix: vi.fn() as any,
+    };
+    const firestore = createFirestoreMock();
+    const apiKeyService: ApiKeyService = {
+      createApiKey: vi.fn() as any,
+      validateApiKey: vi.fn() as any,
+      listApiKeys: vi.fn() as any,
+      revokeApiKey: vi.fn() as any,
+      deleteApiKey: vi.fn() as any,
+      updateLastUsed: vi.fn() as any,
+    };
+
+    const server = createTestServer({ storage, firestore, apiKeyService });
+    const res = await server.request('/upload/my-project/v1.0.0/metadata', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/zip' },
+      body: new Uint8Array([1, 2, 3]),
+    });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app.metadata.test.ts
+++ b/src/app.metadata.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { app, type AppEnv } from './app.js';
 import type { ApiKeyService } from './services/apikey/apikey.service.js';
 import type { FirestoreService } from './services/firestore/firestore.service.js';
+import type { Build } from './services/firestore/firestore.types.js';
 import type { StorageService } from './services/storage/storage.service.js';
 
 function createTestServer(options: {
@@ -15,7 +16,7 @@ function createTestServer(options: {
   wrapper.use('*', async (c, next) => {
     c.set('storage', options.storage);
     if (options.firestore) c.set('firestore', options.firestore);
-    if (options.queue) c.set('queue', options.queue as unknown as Queue);
+    if (options.queue) c.set('processingQueue', options.queue as unknown as Queue);
     if (options.apiKeyService) c.set('apiKeyService', options.apiKeyService);
     await next();
   });
@@ -24,19 +25,22 @@ function createTestServer(options: {
 }
 
 function createFirestoreMock(overrides: Partial<FirestoreService> = {}): FirestoreService {
-  return {
-    createBuild: vi.fn() as any,
-    getBuild: vi.fn() as any,
-    getProjectBuilds: vi.fn() as any,
-    getBuildByVersion: vi.fn() as any,
-    getLatestBuild: vi.fn() as any,
-    updateBuild: vi.fn() as any,
-    updateBuildCoverage: vi.fn() as any,
-    updateProcessingStatus: vi.fn() as any,
-    archiveBuild: vi.fn() as any,
-    deleteBuild: vi.fn() as any,
-    ...overrides,
+  const base: FirestoreService = {
+    createBuild: vi.fn(async () => {
+      throw new Error('createBuild was not mocked for this test');
+    }),
+    getBuild: vi.fn(async () => null),
+    getProjectBuilds: vi.fn(async () => []),
+    getBuildByVersion: vi.fn(async () => null),
+    getLatestBuild: vi.fn(async () => null),
+    updateBuild: vi.fn(async () => undefined),
+    updateBuildCoverage: vi.fn(async () => undefined),
+    updateProcessingStatus: vi.fn(async () => undefined),
+    archiveBuild: vi.fn(async () => undefined),
+    deleteBuild: vi.fn(async () => undefined),
   };
+
+  return { ...base, ...overrides };
 }
 
 describe('app metadata route', () => {
@@ -53,8 +57,7 @@ describe('app metadata route', () => {
       deleteByPrefix: vi.fn() as any,
     };
 
-    const firestore = createFirestoreMock({
-      getLatestBuild: vi.fn(async () => ({
+    const latestBuild: Build = {
         id: 'build-123',
         projectId: 'my-project',
         versionId: 'v1.0.0',
@@ -63,8 +66,10 @@ describe('app metadata route', () => {
         status: 'active',
         createdAt: new Date(),
         createdBy: 'test',
-      })) as any,
-      updateProcessingStatus: vi.fn(async () => undefined) as any,
+    };
+    const firestore = createFirestoreMock({
+      getLatestBuild: vi.fn(async () => latestBuild),
+      updateProcessingStatus: vi.fn(async () => undefined),
     });
 
     const server = createTestServer({
@@ -101,6 +106,23 @@ describe('app metadata route', () => {
     expect(body.buildNumber).toBe(7);
   });
 
+  it('returns 400 when version parameter contains unsafe characters', async () => {
+    const storage: StorageService = {
+      upload: vi.fn() as any,
+      getPresignedUploadUrl: vi.fn() as any,
+      deleteByPrefix: vi.fn() as any,
+    };
+    const firestore = createFirestoreMock();
+    const server = createTestServer({ storage, firestore });
+
+    const res = await server.request('/upload/my-project/%24bad/metadata', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/zip' },
+      body: new Uint8Array([80, 75, 3, 4]),
+    });
+    expect(res.status).toBe(400);
+  });
+
   it('returns 400 when metadata ZIP body is empty', async () => {
     const storage: StorageService = {
       upload: vi.fn() as any,
@@ -128,7 +150,7 @@ describe('app metadata route', () => {
       deleteByPrefix: vi.fn() as any,
     };
     const firestore = createFirestoreMock({
-      getLatestBuild: vi.fn(async () => null) as any,
+      getLatestBuild: vi.fn(async () => null),
     });
     const server = createTestServer({ storage, firestore });
 
@@ -150,8 +172,7 @@ describe('app metadata route', () => {
       getPresignedUploadUrl: vi.fn() as any,
       deleteByPrefix: vi.fn() as any,
     };
-    const firestore = createFirestoreMock({
-      getLatestBuild: vi.fn(async () => ({
+    const latestBuild: Build = {
         id: 'build-123',
         projectId: 'my-project',
         versionId: 'v1.0.0',
@@ -160,8 +181,10 @@ describe('app metadata route', () => {
         status: 'active',
         createdAt: new Date(),
         createdBy: 'test',
-      })) as any,
-      updateProcessingStatus: vi.fn(async () => undefined) as any,
+    };
+    const firestore = createFirestoreMock({
+      getLatestBuild: vi.fn(async () => latestBuild),
+      updateProcessingStatus: vi.fn(async () => undefined),
     });
     const server = createTestServer({ storage, firestore });
 

--- a/src/app.routes.coverage.test.ts
+++ b/src/app.routes.coverage.test.ts
@@ -8,11 +8,13 @@ import type { FirestoreService } from './services/firestore/firestore.service.js
 function createTestServer(options: {
   storage: StorageService;
   firestore?: FirestoreService;
+  cleanupToken?: string;
 }) {
   const wrapper = new Hono<AppEnv>();
   wrapper.use('*', async (c, next) => {
     c.set('storage', options.storage);
     if (options.firestore) c.set('firestore', options.firestore);
+    if (options.cleanupToken) c.set('cleanupToken', options.cleanupToken);
     await next();
   });
   wrapper.route('/', app);
@@ -55,21 +57,24 @@ describe('app routes (coverage)', () => {
     expect(body.key).toBe('my-proj/v1/storybook.zip');
   });
 
-  it('DELETE /cleanup/:project/:version requires X-Test-Cleanup=true', async () => {
+  it('DELETE /cleanup/:project/:version requires configured X-Cleanup-Token', async () => {
     const deleteByPrefix = vi.fn(async () => undefined);
     const storage: StorageService = {
       upload: vi.fn() as any,
       getPresignedUploadUrl: vi.fn() as any,
       deleteByPrefix: deleteByPrefix as any,
     };
-    const server = createTestServer({ storage });
+    const disabledServer = createTestServer({ storage });
+    const disabledRes = await disabledServer.request('/cleanup/my-proj/v1', { method: 'DELETE' });
+    expect(disabledRes.status).toBe(404);
 
+    const server = createTestServer({ storage, cleanupToken: 'cleanup-secret' });
     const res1 = await server.request('/cleanup/my-proj/v1', { method: 'DELETE' });
     expect(res1.status).toBe(401);
 
     const res2 = await server.request('/cleanup/my-proj/v1', {
       method: 'DELETE',
-      headers: { 'X-Test-Cleanup': 'true' },
+      headers: { 'X-Cleanup-Token': 'cleanup-secret' },
     });
     expect(res2.status).toBe(200);
     expect(deleteByPrefix).toHaveBeenCalledWith('my-proj/v1/');
@@ -291,6 +296,22 @@ describe('app routes (coverage)', () => {
     expect(body.buildId).toBeUndefined();
     expect(body.buildNumber).toBeUndefined();
     expect(firestore.createBuild).not.toHaveBeenCalled();
+  });
+
+  it('POST /presigned-url/:project/:version/:filename rejects unsafe filename segments', async () => {
+    const storage: StorageService = {
+      upload: vi.fn() as any,
+      getPresignedUploadUrl: vi.fn() as any,
+      deleteByPrefix: vi.fn() as any,
+    };
+    const server = createTestServer({ storage });
+
+    const res = await server.request('/presigned-url/my-proj/v1/%24bad.zip', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contentType: 'application/zip' }),
+    });
+    expect(res.status).toBe(400);
   });
 
   it('POST /upload/:project/:version/coverage returns 500 if Firestore is not configured', async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,11 @@ import { swaggerUI } from '@hono/swagger-ui';
 import { logger } from 'hono/logger';
 import type { StorageService } from './services/storage/storage.service.js';
 import type { FirestoreService } from './services/firestore/firestore.service.js';
-import type { BuildCoverage, CreateBuildData } from './services/firestore/firestore.types.js';
+import type {
+  BuildCoverage,
+  BuildProcessingStatus,
+  CreateBuildData,
+} from './services/firestore/firestore.types.js';
 import type { ApiKeyService } from './services/apikey/apikey.service.js';
 import { apiKeyAuth, type AuthVariables } from './middleware/auth.js';
 import { normalizeCoverageInput } from './coverage/coverage.js';
@@ -399,6 +403,14 @@ const CoverageUploadResponseSchema = z.object({
   coverageUrl: z.string().optional(),
 });
 
+const MetadataUploadResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string(),
+  queued: z.boolean(),
+  buildNumber: z.number(),
+  zipKey: z.string(),
+});
+
 // Coverage upload route - upload JSON and update build
 const coverageUploadRoute = createRoute({
   method: 'post',
@@ -585,6 +597,115 @@ app.openapi(coverageUploadRoute, async (c) => {
       {
         error: `Coverage upload failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
       },
+      500
+    );
+  }
+});
+
+const metadataUploadRoute = createRoute({
+  method: 'post',
+  path: '/upload/:project/:version/metadata',
+  request: {
+    params: ProjectVersionParamsSchema,
+  },
+  responses: {
+    201: {
+      description: 'Metadata ZIP uploaded',
+      content: {
+        'application/json': {
+          schema: MetadataUploadResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Invalid request payload or missing prior build',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+    401: {
+      description: 'Unauthorized',
+      content: {
+        'application/json': {
+          schema: AuthErrorResponseSchema,
+        },
+      },
+    },
+    500: {
+      description: 'Internal server error',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(metadataUploadRoute, async (c) => {
+  try {
+    const { project, version } = c.req.valid('param');
+    const storage = c.var.storage;
+    const firestore = c.var.firestore;
+    const queue = c.var.processingQueue;
+
+    const body = await c.req.arrayBuffer();
+    if (!body || body.byteLength === 0) {
+      return c.json({ error: 'No file provided' }, 400);
+    }
+
+    if (!firestore) {
+      return c.json({ error: 'Firestore not configured' }, 500);
+    }
+
+    const build = await firestore.getLatestBuild(project, version);
+    if (!build) {
+      return c.json(
+        {
+          error: 'No build found for this project and version. Upload storybook.zip first.',
+        },
+        400
+      );
+    }
+
+    const zipKey = `${project}/${version}/builds/${build.buildNumber}/metadata-screenshots.zip`;
+    await storage.upload(zipKey, new Blob([body]).stream(), 'application/zip');
+
+    let queued = false;
+    if (queue) {
+      await queue.send({
+        projectId: project,
+        versionId: version,
+        buildId: build.id,
+        zipKey,
+        timestamp: Date.now(),
+      });
+      queued = true;
+    }
+
+    const queuedStatus: BuildProcessingStatus = 'queued';
+    if (firestore.updateProcessingStatus) {
+      await firestore.updateProcessingStatus(project, build.id, queuedStatus);
+    } else {
+      await firestore.updateBuild(project, build.id, { processingStatus: queuedStatus });
+    }
+
+    return c.json(
+      {
+        success: true,
+        message: queued ? 'Metadata ZIP uploaded and processing queued' : 'Metadata ZIP uploaded',
+        queued,
+        buildNumber: build.buildNumber,
+        zipKey,
+      },
+      201
+    );
+  } catch (error) {
+    console.error('Metadata upload error:', error);
+    return c.json(
+      { error: `Metadata upload failed: ${error instanceof Error ? error.message : 'Unknown error'}` },
       500
     );
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,7 @@ export type AppEnv = {
     firestore?: FirestoreService; // Optional to support gradual rollout
     apiKeyService?: ApiKeyService; // Optional for API key authentication
     processingQueue?: Queue; // Optional build processing queue
+    cleanupToken?: string;
   } & AuthVariables;
 };
 
@@ -39,21 +40,59 @@ app.use('*', logger());
 app.use('/upload/*', apiKeyAuth());
 app.use('/presigned-url/*', apiKeyAuth());
 
+const PROJECT_SEGMENT_REGEX = /^[a-zA-Z0-9_-]+$/;
+const VERSION_SEGMENT_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+const FILENAME_SEGMENT_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+
 // Define Zod schemas for parameters and responses
 const ProjectVersionParamsSchema = z.object({
-  project: z.string().min(1).regex(/^[a-zA-Z0-9_-]+$/, 'Project name must contain only alphanumeric characters, hyphens, and underscores').openapi({ example: 'my-project' }),
-  version: z.string().min(1).openapi({ 
-    example: 'v1.0.0',
-    description: 'Version identifier - supports semantic versions (v1.0.0), PR builds (pr-001), extended versions (v0.0.0.1), and named releases (beta-2024, dev-123, staging, latest)',
-    examples: ['v1.0.0', 'pr-001', 'v0.0.0.1', 'beta-2024', 'dev-snapshot-123', 'staging', 'latest', 'main']
-  })
+  project: z.string().min(1).regex(PROJECT_SEGMENT_REGEX, 'Project name must contain only alphanumeric characters, hyphens, and underscores').openapi({ example: 'my-project' }),
+  version: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      VERSION_SEGMENT_REGEX,
+      'Version must contain only alphanumeric characters, periods, hyphens, and underscores'
+    )
+    .openapi({
+      example: 'v1.0.0',
+      description:
+        'Version identifier - supports semantic versions (v1.0.0), PR builds (pr-001), extended versions (v0.0.0.1), and named releases (beta-2024, dev-123, staging, latest)',
+      examples: ['v1.0.0', 'pr-001', 'v0.0.0.1', 'beta-2024', 'dev-snapshot-123', 'staging', 'latest', 'main'],
+    }),
 });
 
 const ProjectVersionFilenameParamsSchema = z.object({
-  project: z.string().min(1).regex(/^[a-zA-Z0-9_-]+$/, 'Project name must contain only alphanumeric characters, hyphens, and underscores').openapi({ example: 'my-project' }),
-  version: z.string().min(1).openapi({ example: '1.0.0' }),
-  filename: z.string().openapi({ example: 'storybook.zip' })
+  project: z.string().min(1).regex(PROJECT_SEGMENT_REGEX, 'Project name must contain only alphanumeric characters, hyphens, and underscores').openapi({ example: 'my-project' }),
+  version: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      VERSION_SEGMENT_REGEX,
+      'Version must contain only alphanumeric characters, periods, hyphens, and underscores'
+    )
+    .openapi({ example: '1.0.0' }),
+  filename: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      FILENAME_SEGMENT_REGEX,
+      'Filename must contain only alphanumeric characters, periods, hyphens, and underscores'
+    )
+    .openapi({ example: 'storybook.zip' }),
 });
+
+function constantTimeEquals(left: string, right: string): boolean {
+  if (left.length !== right.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < left.length; i += 1) {
+    mismatch |= left.charCodeAt(i) ^ right.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
 
 const UploadResponseSchema = z.object({
   success: z.boolean(),
@@ -882,13 +921,26 @@ const cleanupRoute = createRoute({
           schema: ErrorResponseSchema
         }
       }
+    },
+    404: {
+      description: 'Cleanup endpoint disabled',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema
+        }
+      }
     }
   }
 });
 
 app.openapi(cleanupRoute, async (c) => {
-  const cleanupHeader = c.req.header('X-Test-Cleanup');
-  if (cleanupHeader !== 'true') {
+  const configuredCleanupToken = c.var.cleanupToken;
+  if (!configuredCleanupToken) {
+    return c.json({ error: 'Cleanup endpoint is disabled' }, 404);
+  }
+
+  const cleanupHeader = c.req.header('X-Cleanup-Token') || '';
+  if (!constantTimeEquals(cleanupHeader, configuredCleanupToken)) {
     return c.json({ error: 'Unauthorized cleanup request' }, 401);
   }
 

--- a/src/entry.node.ts
+++ b/src/entry.node.ts
@@ -97,6 +97,9 @@ nodeApp.use('*', async (c, next) => {
     const apiKeyService = new ApiKeyServiceNode();
     c.set('apiKeyService', apiKeyService);
   }
+  if (process.env.CLEANUP_TOKEN) {
+    c.set('cleanupToken', process.env.CLEANUP_TOKEN);
+  }
   
   await next();
 });

--- a/src/entry.worker.ts
+++ b/src/entry.worker.ts
@@ -39,6 +39,9 @@ type Bindings = {
   BUILD_PROCESSING_QUEUE?: Queue;
   // Environment variable to detect test mode
   NODE_ENV?: string;
+
+  // Shared secret used to authorize cleanup requests.
+  CLEANUP_TOKEN?: string;
 };
 
 // Create a new Hono instance specifically for the Worker, extending the shared AppEnv.
@@ -135,6 +138,9 @@ workerApp.use('*', async (c, next) => {
   // Inject processing queue if available
   if (c.env.BUILD_PROCESSING_QUEUE) {
     c.set('processingQueue', c.env.BUILD_PROCESSING_QUEUE);
+  }
+  if (c.env.CLEANUP_TOKEN) {
+    c.set('cleanupToken', c.env.CLEANUP_TOKEN);
   }
 
   await next();

--- a/src/entry.worker.ts
+++ b/src/entry.worker.ts
@@ -37,7 +37,6 @@ type Bindings = {
 
   // Build processing queue
   BUILD_PROCESSING_QUEUE?: Queue;
-
   // Environment variable to detect test mode
   NODE_ENV?: string;
 };

--- a/src/services/firestore/firestore.node.ts
+++ b/src/services/firestore/firestore.node.ts
@@ -1,7 +1,14 @@
 import admin from 'firebase-admin';
 import type { Firestore, FieldValue } from 'firebase-admin/firestore';
 import type { FirestoreService } from './firestore.service.js';
-import type { Build, BuildCoverage, CreateBuildData, UpdateBuildData, BuildStatus } from './firestore.types.js';
+import type {
+  Build,
+  BuildCoverage,
+  BuildProcessingStatus,
+  BuildStatus,
+  CreateBuildData,
+  UpdateBuildData,
+} from './firestore.types.js';
 
 /**
  * Node.js implementation of FirestoreService using Firebase Admin SDK
@@ -153,8 +160,13 @@ export class FirestoreServiceNode implements FirestoreService {
    * Gets the latest active build for a project
    */
   async getLatestBuild(
-    projectId: string
+    projectId: string,
+    versionId?: string
   ): Promise<Build | null> {
+    if (versionId) {
+      return this.getBuildByVersion(projectId, versionId);
+    }
+
     const snapshot = await this.db.collection(`projects/${projectId}/builds`)
       .where('status', '==', 'active')
       .orderBy('buildNumber', 'desc')
@@ -191,6 +203,18 @@ export class FirestoreServiceNode implements FirestoreService {
   ): Promise<void> {
     const buildRef = this.db.doc(`projects/${projectId}/builds/${buildId}`);
     await buildRef.update({ coverage } as any);
+  }
+
+  /**
+   * Updates metadata processing status for a build.
+   */
+  async updateProcessingStatus(
+    projectId: string,
+    buildId: string,
+    status: BuildProcessingStatus
+  ): Promise<void> {
+    const buildRef = this.db.doc(`projects/${projectId}/builds/${buildId}`);
+    await buildRef.update({ processingStatus: status } as any);
   }
 
   /**
@@ -236,6 +260,7 @@ export class FirestoreServiceNode implements FirestoreService {
       archivedAt: data.archivedAt?.toDate?.(),
       archivedBy: data.archivedBy,
       coverage: data.coverage,
+      processingStatus: data.processingStatus,
     };
   }
 }

--- a/src/services/firestore/firestore.service.ts
+++ b/src/services/firestore/firestore.service.ts
@@ -1,4 +1,11 @@
-import type { Build, BuildCoverage, CreateBuildData, UpdateBuildData, BuildStatus } from './firestore.types.js';
+import type {
+  Build,
+  BuildCoverage,
+  BuildProcessingStatus,
+  BuildStatus,
+  CreateBuildData,
+  UpdateBuildData,
+} from './firestore.types.js';
 
 /**
  * Defines the contract for all Firestore operations within the application.
@@ -57,7 +64,8 @@ export interface FirestoreService {
    * @returns A promise that resolves to the latest Build record or null if none found
    */
   getLatestBuild(
-    projectId: string
+    projectId: string,
+    versionId?: string
   ): Promise<Build | null>;
 
   /**
@@ -101,6 +109,18 @@ export interface FirestoreService {
     projectId: string,
     buildId: string,
     coverage: BuildCoverage
+  ): Promise<void>;
+
+  /**
+   * Updates the metadata processing state for a build.
+   * @param projectId The project identifier
+   * @param buildId The build identifier
+   * @param status The processing status value
+   */
+  updateProcessingStatus?(
+    projectId: string,
+    buildId: string,
+    status: BuildProcessingStatus
   ): Promise<void>;
 
   /**

--- a/src/services/firestore/firestore.types.ts
+++ b/src/services/firestore/firestore.types.ts
@@ -2,6 +2,7 @@
  * Represents the status of a build in the system
  */
 export type BuildStatus = 'active' | 'archived';
+export type BuildProcessingStatus = 'queued' | 'processing' | 'completed' | 'partial' | 'failed';
 
 /**
  * Summary metrics extracted from a coverage report.
@@ -119,6 +120,11 @@ export interface Build {
    * Normalized coverage data for the build (if uploaded).
    */
   coverage?: BuildCoverage;
+
+  /**
+   * Async processing state for screenshot metadata ingestion.
+   */
+  processingStatus?: BuildProcessingStatus;
 }
 
 /**
@@ -169,4 +175,9 @@ export interface UpdateBuildData {
    * Normalized coverage data for the build (if uploaded).
    */
   coverage?: BuildCoverage;
+
+  /**
+   * Async processing state for screenshot metadata ingestion.
+   */
+  processingStatus?: BuildProcessingStatus;
 }

--- a/src/services/firestore/firestore.worker.ts
+++ b/src/services/firestore/firestore.worker.ts
@@ -1,5 +1,12 @@
 import type { FirestoreService } from './firestore.service.js';
-import type { Build, BuildCoverage, CreateBuildData, UpdateBuildData, BuildStatus } from './firestore.types.js';
+import type {
+  Build,
+  BuildCoverage,
+  BuildProcessingStatus,
+  BuildStatus,
+  CreateBuildData,
+  UpdateBuildData,
+} from './firestore.types.js';
 
 interface FirestoreConfig {
   projectId: string;
@@ -276,8 +283,13 @@ export class FirestoreServiceWorker implements FirestoreService {
    * Gets the latest active build for a project
    */
   async getLatestBuild(
-    projectId: string
+    projectId: string,
+    versionId?: string
   ): Promise<Build | null> {
+    if (versionId) {
+      return this.getBuildByVersion(projectId, versionId);
+    }
+
     const token = await this.getAccessToken();
     
     const structuredQuery = {
@@ -317,6 +329,7 @@ export class FirestoreServiceWorker implements FirestoreService {
     if (updates.archivedAt) fields.archivedAt = { timestampValue: updates.archivedAt.toISOString() };
     if (updates.archivedBy) fields.archivedBy = { stringValue: updates.archivedBy };
     if (updates.coverage) fields.coverage = this.toFirestoreValue(updates.coverage);
+    if (updates.processingStatus) fields.processingStatus = { stringValue: updates.processingStatus };
 
     await this.patchDocument(buildPath, fields, token);
   }
@@ -353,6 +366,19 @@ export class FirestoreServiceWorker implements FirestoreService {
     const buildPath = `projects/${projectId}/builds/${buildId}`;
 
     await this.patchDocument(buildPath, { coverage: this.toFirestoreValue(coverage) }, token);
+  }
+
+  /**
+   * Updates metadata processing status for a build.
+   */
+  async updateProcessingStatus(
+    projectId: string,
+    buildId: string,
+    status: BuildProcessingStatus
+  ): Promise<void> {
+    const token = await this.getAccessToken();
+    const buildPath = `projects/${projectId}/builds/${buildId}`;
+    await this.patchDocument(buildPath, { processingStatus: { stringValue: status } }, token);
   }
 
   /**
@@ -556,6 +582,7 @@ export class FirestoreServiceWorker implements FirestoreService {
       archivedAt: fields.archivedAt?.timestampValue ? new Date(fields.archivedAt.timestampValue) : undefined,
       archivedBy: fields.archivedBy?.stringValue,
       coverage: fields.coverage ? (this.fromFirestoreValue(fields.coverage) as any) : undefined,
+      processingStatus: fields.processingStatus?.stringValue,
     };
   }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,6 +27,10 @@ bucket_name = "my-storybooks-production"
 # For local development, a preview bucket can be specified.
 preview_bucket_name = "my-storybooks-staging"
 
+[[queues.producers]]
+queue = "scry-build-processing"
+binding = "BUILD_PROCESSING_QUEUE"
+
 # --- Environment Variables and Secrets ---
 # The following variables are required for the S3-compatible API to work.
 # For local development with `wrangler dev`, you can define them in this `.dev.vars` file.
@@ -59,11 +63,11 @@ binding = "STORYBOOK_BUCKET"
 bucket_name = "my-storybooks-staging"
 preview_bucket_name = "my-storybooks-staging"
 
-# Observability and Logging Configuration
-[[queues.producers]]
-queue = "scry-build-processing"
+[[env.preview.queues.producers]]
+queue = "scry-build-processing-preview"
 binding = "BUILD_PROCESSING_QUEUE"
 
+# Observability and Logging Configuration
 [observability]
 [observability.logs]
 enabled = true  # Enable logging

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -49,6 +49,7 @@ R2_BUCKET_NAME = "my-storybooks-production"
 # - FIREBASE_PROJECT_ID
 # - FIREBASE_CLIENT_EMAIL
 # - FIREBASE_PRIVATE_KEY
+# - CLEANUP_TOKEN (required to enable DELETE /cleanup/:project/:version)
 # - SENTRY_DSN (Sentry Data Source Name for error tracking)
 #
 # DO NOT add placeholder values here - they will override secrets!


### PR DESCRIPTION
Adds POST /upload/:project/:version/metadata, queue producer wiring, Firestore processingStatus updates, and route tests.