### PR TITLE
feat: image upload routes and Firestore CRUD

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import type {
   BuildCoverage,
   BuildProcessingStatus,
   CreateBuildData,
+  CreateUploadData,
 } from './services/firestore/firestore.types.js';
 import type { ApiKeyService } from './services/apikey/apikey.service.js';
 import { apiKeyAuth, type AuthVariables } from './middleware/auth.js';
@@ -39,6 +40,7 @@ app.use('*', logger());
 // This middleware validates the X-API-Key header against Firestore-stored keys
 app.use('/upload/*', apiKeyAuth());
 app.use('/presigned-url/*', apiKeyAuth());
+app.use('/upload-images/*', apiKeyAuth());
 
 const PROJECT_SEGMENT_REGEX = /^[a-zA-Z0-9_-]+$/;
 const VERSION_SEGMENT_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
@@ -951,6 +953,190 @@ app.openapi(cleanupRoute, async (c) => {
   await storage.deleteByPrefix(prefix);
 
   return c.json({ message: 'Cleanup completed' }, 200);
+});
+
+// ============= IMAGE UPLOAD ROUTES =============
+
+const ImageUploadInitResponseSchema = z.object({
+  success: z.boolean(),
+  uploadId: z.string(),
+  uploadNumber: z.number(),
+  presignedUrl: z.string(),
+  zipKey: z.string(),
+});
+
+const ImageUploadCompleteResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string(),
+  queued: z.boolean(),
+});
+
+const ProjectParamSchema = z.object({
+  project: z.string().min(1).regex(PROJECT_SEGMENT_REGEX, 'Project name must contain only alphanumeric characters, hyphens, and underscores').openapi({ example: 'my-project' }),
+});
+
+// POST /upload-images/:project — Initialize upload, create Firestore record, return presigned URL
+const imageUploadInitRoute = createRoute({
+  method: 'post',
+  path: '/upload-images/:project',
+  request: {
+    params: ProjectParamSchema,
+  },
+  responses: {
+    201: {
+      description: 'Upload initialized with presigned URL',
+      content: {
+        'application/json': {
+          schema: ImageUploadInitResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Invalid request',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+    500: {
+      description: 'Internal server error',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+  },
+});
+
+app.openapi(imageUploadInitRoute, async (c) => {
+  try {
+    const { project } = c.req.valid('param');
+    const storage = c.var.storage;
+    const firestore = c.var.firestore;
+
+    if (!firestore) {
+      return c.json({ error: 'Firestore not configured' }, 500);
+    }
+
+    // Parse optional body for image count
+    let imageCount = 0;
+    try {
+      const body = await c.req.json();
+      imageCount = body.imageCount || 0;
+    } catch {
+      // No body is ok
+    }
+
+    // Create upload record in Firestore
+    const upload = await firestore.createUpload(project, {
+      imageCount,
+      zipUrl: '', // Will be set after upload
+    });
+
+    // Generate presigned URL for ZIP upload
+    const zipKey = `${project}/uploads/${upload.uploadNumber}/images.zip`;
+    const presignedData = await storage.getPresignedUploadUrl(zipKey, 'application/zip');
+
+    return c.json(
+      {
+        success: true,
+        uploadId: upload.id,
+        uploadNumber: upload.uploadNumber,
+        presignedUrl: presignedData.url,
+        zipKey,
+      },
+      201
+    );
+  } catch (error) {
+    console.error('Image upload init error:', error);
+    return c.json(
+      { error: `Upload initialization failed: ${error instanceof Error ? error.message : 'Unknown error'}` },
+      500
+    );
+  }
+});
+
+// POST /upload-images/:project/complete — Signal upload complete, enqueue for processing
+const imageUploadCompleteRoute = createRoute({
+  method: 'post',
+  path: '/upload-images/:project/complete',
+  request: {
+    params: ProjectParamSchema,
+  },
+  responses: {
+    200: {
+      description: 'Upload queued for processing',
+      content: {
+        'application/json': {
+          schema: ImageUploadCompleteResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Invalid request',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+    500: {
+      description: 'Internal server error',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+  },
+});
+
+app.openapi(imageUploadCompleteRoute, async (c) => {
+  try {
+    const { project } = c.req.valid('param');
+    const firestore = c.var.firestore;
+    const queue = c.var.processingQueue;
+
+    if (!firestore) {
+      return c.json({ error: 'Firestore not configured' }, 500);
+    }
+
+    let uploadId: string;
+    let zipKey: string;
+    try {
+      const body = await c.req.json();
+      uploadId = body.uploadId;
+      zipKey = body.zipKey;
+    } catch {
+      return c.json({ error: 'Request body must include uploadId and zipKey' }, 400);
+    }
+
+    if (!uploadId || !zipKey) {
+      return c.json({ error: 'uploadId and zipKey are required' }, 400);
+    }
+
+    // Update upload status to queued
+    await firestore.updateUploadProcessingStatus(project, uploadId, 'queued');
+
+    // Enqueue for worker processing
+    let queued = false;
+    if (queue) {
+      await queue.send({
+        type: 'upload',
+        projectId: project,
+        uploadId,
+        zipKey,
+        timestamp: Date.now(),
+      });
+      queued = true;
+    }
+
+    return c.json({
+      success: true,
+      message: queued ? 'Upload queued for processing' : 'Upload recorded (no processing queue configured)',
+      queued,
+    }, 200);
+  } catch (error) {
+    console.error('Image upload complete error:', error);
+    return c.json(
+      { error: `Upload completion failed: ${error instanceof Error ? error.message : 'Unknown error'}` },
+      500
+    );
+  }
 });
 
 // Serve OpenAPI spec

--- a/src/app.ts
+++ b/src/app.ts
@@ -975,6 +975,11 @@ const ProjectParamSchema = z.object({
   project: z.string().min(1).regex(PROJECT_SEGMENT_REGEX, 'Project name must contain only alphanumeric characters, hyphens, and underscores').openapi({ example: 'my-project' }),
 });
 
+const ImageUploadCompleteBodySchema = z.object({
+  uploadId: z.string().min(1, 'uploadId is required'),
+  zipKey: z.string().min(1, 'zipKey is required'),
+});
+
 // POST /upload-images/:project — Initialize upload, create Firestore record, return presigned URL
 const imageUploadInitRoute = createRoute({
   method: 'post',
@@ -1060,6 +1065,13 @@ const imageUploadCompleteRoute = createRoute({
   path: '/upload-images/:project/complete',
   request: {
     params: ProjectParamSchema,
+    body: {
+      content: {
+        'application/json': {
+          schema: ImageUploadCompleteBodySchema,
+        },
+      },
+    },
   },
   responses: {
     200: {
@@ -1095,19 +1107,7 @@ app.openapi(imageUploadCompleteRoute, async (c) => {
       return c.json({ error: 'Firestore not configured' }, 500);
     }
 
-    let uploadId: string;
-    let zipKey: string;
-    try {
-      const body = await c.req.json();
-      uploadId = body.uploadId;
-      zipKey = body.zipKey;
-    } catch {
-      return c.json({ error: 'Request body must include uploadId and zipKey' }, 400);
-    }
-
-    if (!uploadId || !zipKey) {
-      return c.json({ error: 'uploadId and zipKey are required' }, 400);
-    }
+    const { uploadId, zipKey } = c.req.valid('json');
 
     // Update upload status to queued
     await firestore.updateUploadProcessingStatus(project, uploadId, 'queued');

--- a/src/services/firestore/firestore.node.ts
+++ b/src/services/firestore/firestore.node.ts
@@ -8,6 +8,8 @@ import type {
   BuildStatus,
   CreateBuildData,
   UpdateBuildData,
+  Upload,
+  CreateUploadData,
 } from './firestore.types.js';
 
 /**
@@ -242,6 +244,106 @@ export class FirestoreServiceNode implements FirestoreService {
   ): Promise<void> {
     const buildRef = this.db.doc(`projects/${projectId}/builds/${buildId}`);
     await buildRef.delete();
+  }
+
+  // ============= UPLOAD OPERATIONS =============
+
+  async createUpload(
+    projectId: string,
+    data: CreateUploadData
+  ): Promise<Upload> {
+    return this.db.runTransaction(async (transaction) => {
+      const counterRef = this.db.doc(`projects/${projectId}/counters/uploads`);
+      const counterSnap = await transaction.get(counterRef);
+
+      let uploadNumber = 1;
+      if (!counterSnap.exists) {
+        transaction.set(counterRef, { currentUploadNumber: 1 });
+      } else {
+        uploadNumber = counterSnap.data()!.currentUploadNumber + 1;
+        transaction.update(counterRef, {
+          currentUploadNumber: admin.firestore.FieldValue.increment(1) as any
+        });
+      }
+
+      const uploadRef = this.db.collection(`projects/${projectId}/uploads`).doc();
+      const uploadData = {
+        projectId,
+        uploadNumber,
+        imageCount: data.imageCount,
+        zipUrl: data.zipUrl,
+        status: 'active' as const,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        createdBy: this.serviceAccountId,
+      };
+
+      transaction.set(uploadRef, uploadData);
+
+      return {
+        id: uploadRef.id,
+        projectId,
+        uploadNumber,
+        imageCount: data.imageCount,
+        zipUrl: data.zipUrl,
+        status: 'active' as const,
+        createdAt: new Date(),
+        createdBy: this.serviceAccountId,
+      };
+    });
+  }
+
+  async getUpload(
+    projectId: string,
+    uploadId: string
+  ): Promise<Upload | null> {
+    const ref = this.db.doc(`projects/${projectId}/uploads/${uploadId}`);
+    const snap = await ref.get();
+
+    if (!snap.exists) return null;
+    return this.convertDocToUpload(snap.id, snap.data()!);
+  }
+
+  async getProjectUploads(
+    projectId: string,
+    limitCount: number = 50
+  ): Promise<Upload[]> {
+    const snapshot = await this.db.collection(`projects/${projectId}/uploads`)
+      .orderBy('uploadNumber', 'desc')
+      .limit(limitCount)
+      .get();
+
+    return snapshot.docs.map(doc => this.convertDocToUpload(doc.id, doc.data()));
+  }
+
+  async updateUploadProcessingStatus(
+    projectId: string,
+    uploadId: string,
+    status: BuildProcessingStatus
+  ): Promise<void> {
+    const ref = this.db.doc(`projects/${projectId}/uploads/${uploadId}`);
+    await ref.update({ processingStatus: status } as any);
+  }
+
+  async deleteUpload(
+    projectId: string,
+    uploadId: string
+  ): Promise<void> {
+    const ref = this.db.doc(`projects/${projectId}/uploads/${uploadId}`);
+    await ref.delete();
+  }
+
+  private convertDocToUpload(id: string, data: any): Upload {
+    return {
+      id,
+      projectId: data.projectId,
+      uploadNumber: data.uploadNumber,
+      imageCount: data.imageCount,
+      zipUrl: data.zipUrl,
+      status: data.status,
+      processingStatus: data.processingStatus,
+      createdAt: data.createdAt?.toDate?.() || new Date(),
+      createdBy: data.createdBy,
+    };
   }
 
   /**

--- a/src/services/firestore/firestore.node.ts
+++ b/src/services/firestore/firestore.node.ts
@@ -262,7 +262,7 @@ export class FirestoreServiceNode implements FirestoreService {
       } else {
         uploadNumber = counterSnap.data()!.currentUploadNumber + 1;
         transaction.update(counterRef, {
-          currentUploadNumber: admin.firestore.FieldValue.increment(1) as any
+          currentUploadNumber: admin.firestore.FieldValue.increment(1),
         });
       }
 
@@ -321,7 +321,7 @@ export class FirestoreServiceNode implements FirestoreService {
     status: BuildProcessingStatus
   ): Promise<void> {
     const ref = this.db.doc(`projects/${projectId}/uploads/${uploadId}`);
-    await ref.update({ processingStatus: status } as any);
+    await ref.update({ processingStatus: status });
   }
 
   async deleteUpload(

--- a/src/services/firestore/firestore.service.ts
+++ b/src/services/firestore/firestore.service.ts
@@ -5,6 +5,8 @@ import type {
   BuildStatus,
   CreateBuildData,
   UpdateBuildData,
+  Upload,
+  CreateUploadData,
 } from './firestore.types.js';
 
 /**
@@ -132,5 +134,48 @@ export interface FirestoreService {
   deleteBuild(
     projectId: string,
     buildId: string
+  ): Promise<void>;
+
+  // ============= UPLOAD OPERATIONS =============
+
+  /**
+   * Creates a new upload record with auto-incrementing upload number
+   */
+  createUpload(
+    projectId: string,
+    data: CreateUploadData
+  ): Promise<Upload>;
+
+  /**
+   * Retrieves an upload by its ID
+   */
+  getUpload(
+    projectId: string,
+    uploadId: string
+  ): Promise<Upload | null>;
+
+  /**
+   * Gets all uploads for a project
+   */
+  getProjectUploads(
+    projectId: string,
+    limitCount?: number
+  ): Promise<Upload[]>;
+
+  /**
+   * Updates the processing status of an upload
+   */
+  updateUploadProcessingStatus(
+    projectId: string,
+    uploadId: string,
+    status: BuildProcessingStatus
+  ): Promise<void>;
+
+  /**
+   * Deletes an upload record
+   */
+  deleteUpload(
+    projectId: string,
+    uploadId: string
   ): Promise<void>;
 }

--- a/src/services/firestore/firestore.types.ts
+++ b/src/services/firestore/firestore.types.ts
@@ -147,6 +147,29 @@ export interface CreateBuildData {
   coverage?: BuildCoverage;
 }
 
+// ============= UPLOAD TYPES =============
+
+export type UploadStatus = 'active' | 'archived';
+
+export interface Upload {
+  id: string;
+  projectId: string;
+  uploadNumber: number;
+  imageCount: number;
+  zipUrl: string;
+  status: UploadStatus;
+  processingStatus?: BuildProcessingStatus;
+  createdAt: Date;
+  createdBy: string;
+}
+
+export interface CreateUploadData {
+  imageCount: number;
+  zipUrl: string;
+}
+
+// ============= BUILD UPDATE TYPES =============
+
 /**
  * Data that can be updated in a build record
  */

--- a/src/services/firestore/firestore.worker.ts
+++ b/src/services/firestore/firestore.worker.ts
@@ -408,6 +408,12 @@ export class FirestoreServiceWorker implements FirestoreService {
 
   // ============= UPLOAD OPERATIONS =============
 
+  /**
+   * Creates a new upload record with auto-incrementing upload number.
+   * Note: REST API doesn't support true transactions, so we use a simplified approach
+   * (same as createBuild). The Node.js implementation uses Firestore transactions
+   * for atomicity.
+   */
   async createUpload(
     projectId: string,
     data: CreateUploadData
@@ -423,8 +429,8 @@ export class FirestoreServiceWorker implements FirestoreService {
       if (counterDoc && counterDoc.fields?.currentUploadNumber?.integerValue) {
         uploadNumber = parseInt(counterDoc.fields.currentUploadNumber.integerValue) + 1;
       }
-    } catch {
-      // Counter doesn't exist, will create it
+    } catch (error) {
+      console.error(`Failed to read upload counter for project ${projectId}:`, error);
     }
 
     // Update counter
@@ -472,7 +478,8 @@ export class FirestoreServiceWorker implements FirestoreService {
       const doc = await this.getDocument(uploadPath, token);
       if (!doc) return null;
       return this.convertDocToUpload(uploadId, doc.fields);
-    } catch {
+    } catch (error) {
+      console.error(`Failed to get upload ${uploadId} for project ${projectId}:`, error);
       return null;
     }
   }
@@ -527,13 +534,19 @@ export class FirestoreServiceWorker implements FirestoreService {
   }
 
   private convertDocToUpload(id: string, fields: any): Upload {
+    const projectId = fields.projectId?.stringValue;
+    const uploadNumber = fields.uploadNumber?.integerValue;
+    if (!projectId || uploadNumber === undefined) {
+      throw new Error(`Upload document ${id} is missing required fields (projectId, uploadNumber)`);
+    }
+
     return {
       id,
-      projectId: fields.projectId?.stringValue || '',
-      uploadNumber: parseInt(fields.uploadNumber?.integerValue || '0'),
+      projectId,
+      uploadNumber: parseInt(uploadNumber),
       imageCount: parseInt(fields.imageCount?.integerValue || '0'),
       zipUrl: fields.zipUrl?.stringValue || '',
-      status: (fields.status?.stringValue || 'active') as any,
+      status: (fields.status?.stringValue || 'active') as Upload['status'],
       processingStatus: fields.processingStatus?.stringValue,
       createdAt: new Date(fields.createdAt?.timestampValue || new Date()),
       createdBy: fields.createdBy?.stringValue || '',

--- a/src/services/firestore/firestore.worker.ts
+++ b/src/services/firestore/firestore.worker.ts
@@ -6,6 +6,8 @@ import type {
   BuildStatus,
   CreateBuildData,
   UpdateBuildData,
+  Upload,
+  CreateUploadData,
 } from './firestore.types.js';
 
 interface FirestoreConfig {
@@ -402,6 +404,140 @@ export class FirestoreServiceWorker implements FirestoreService {
     if (!response.ok) {
       throw new Error(`Failed to delete build: ${response.statusText}`);
     }
+  }
+
+  // ============= UPLOAD OPERATIONS =============
+
+  async createUpload(
+    projectId: string,
+    data: CreateUploadData
+  ): Promise<Upload> {
+    const token = await this.getAccessToken();
+
+    // Get current upload number
+    const counterPath = `projects/${projectId}/counters/uploads`;
+    let uploadNumber = 1;
+
+    try {
+      const counterDoc = await this.getDocument(counterPath, token);
+      if (counterDoc && counterDoc.fields?.currentUploadNumber?.integerValue) {
+        uploadNumber = parseInt(counterDoc.fields.currentUploadNumber.integerValue) + 1;
+      }
+    } catch {
+      // Counter doesn't exist, will create it
+    }
+
+    // Update counter
+    await this.setDocument(counterPath, {
+      currentUploadNumber: { integerValue: uploadNumber.toString() }
+    }, token);
+
+    // Create upload document
+    const uploadId = this.generateId();
+    const uploadPath = `projects/${projectId}/uploads/${uploadId}`;
+    const now = new Date();
+
+    const uploadDoc = {
+      projectId: { stringValue: projectId },
+      uploadNumber: { integerValue: uploadNumber.toString() },
+      imageCount: { integerValue: data.imageCount.toString() },
+      zipUrl: { stringValue: data.zipUrl },
+      status: { stringValue: 'active' },
+      createdAt: { timestampValue: now.toISOString() },
+      createdBy: { stringValue: this.config.serviceAccountId },
+    };
+
+    await this.setDocument(uploadPath, uploadDoc, token);
+
+    return {
+      id: uploadId,
+      projectId,
+      uploadNumber,
+      imageCount: data.imageCount,
+      zipUrl: data.zipUrl,
+      status: 'active',
+      createdAt: now,
+      createdBy: this.config.serviceAccountId,
+    };
+  }
+
+  async getUpload(
+    projectId: string,
+    uploadId: string
+  ): Promise<Upload | null> {
+    const token = await this.getAccessToken();
+    const uploadPath = `projects/${projectId}/uploads/${uploadId}`;
+
+    try {
+      const doc = await this.getDocument(uploadPath, token);
+      if (!doc) return null;
+      return this.convertDocToUpload(uploadId, doc.fields);
+    } catch {
+      return null;
+    }
+  }
+
+  async getProjectUploads(
+    projectId: string,
+    limitCount: number = 50
+  ): Promise<Upload[]> {
+    const token = await this.getAccessToken();
+
+    const structuredQuery: any = {
+      from: [{ collectionId: 'uploads' }],
+      orderBy: [{ field: { fieldPath: 'uploadNumber' }, direction: 'DESCENDING' }],
+      limit: limitCount
+    };
+
+    const docs = await this.queryDocuments(`projects/${projectId}`, structuredQuery, token);
+    return docs.map(doc => {
+      const id = doc.name.split('/').pop()!;
+      return this.convertDocToUpload(id, doc.fields);
+    });
+  }
+
+  async updateUploadProcessingStatus(
+    projectId: string,
+    uploadId: string,
+    status: BuildProcessingStatus
+  ): Promise<void> {
+    const token = await this.getAccessToken();
+    const uploadPath = `projects/${projectId}/uploads/${uploadId}`;
+    await this.patchDocument(uploadPath, { processingStatus: { stringValue: status } }, token);
+  }
+
+  async deleteUpload(
+    projectId: string,
+    uploadId: string
+  ): Promise<void> {
+    const token = await this.getAccessToken();
+    const uploadPath = `projects/${projectId}/uploads/${uploadId}`;
+
+    const url = `${this.baseUrl}/${uploadPath}`;
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete upload: ${response.statusText}`);
+    }
+  }
+
+  private convertDocToUpload(id: string, fields: any): Upload {
+    return {
+      id,
+      projectId: fields.projectId?.stringValue || '',
+      uploadNumber: parseInt(fields.uploadNumber?.integerValue || '0'),
+      imageCount: parseInt(fields.imageCount?.integerValue || '0'),
+      zipUrl: fields.zipUrl?.stringValue || '',
+      status: (fields.status?.stringValue || 'active') as any,
+      processingStatus: fields.processingStatus?.stringValue,
+      createdAt: new Date(fields.createdAt?.timestampValue || new Date()),
+      createdBy: fields.createdBy?.stringValue || '',
+    };
   }
 
   /**

--- a/src/services/firestore/firestore.worker.upload.test.ts
+++ b/src/services/firestore/firestore.worker.upload.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FirestoreServiceWorker } from './firestore.worker.js';
+
+function createSvc() {
+  const svc = new FirestoreServiceWorker({
+    projectId: 'firebase-proj',
+    clientEmail: 'test@example.com',
+    privateKey: '-----BEGIN PRIVATE KEY-----\\nZm9v\\n-----END PRIVATE KEY-----',
+    serviceAccountId: 'upload-service',
+  });
+
+  // Bypass token generation logic.
+  (svc as any).accessToken = 'test-token';
+  (svc as any).tokenExpiry = Date.now() + 60_000;
+
+  return svc;
+}
+
+describe('FirestoreServiceWorker — Upload CRUD', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('createUpload() increments upload counter and writes the upload doc', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = (init?.method || 'GET').toUpperCase();
+
+      // GET counter
+      if (method === 'GET' && url.includes('/documents/projects/my-project/counters/uploads')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            fields: { currentUploadNumber: { integerValue: '3' } },
+          }),
+        } as any;
+      }
+
+      // PATCH counter (increment)
+      if (method === 'PATCH' && url.includes('/documents/projects/my-project/counters/uploads')) {
+        const body = JSON.parse(String(init?.body));
+        expect(body.fields.currentUploadNumber.integerValue).toBe('4');
+        return { ok: true, status: 200, json: async () => ({}) } as any;
+      }
+
+      // PATCH upload document
+      if (method === 'PATCH' && url.includes('/documents/projects/my-project/uploads/')) {
+        const body = JSON.parse(String(init?.body));
+        expect(body.fields.projectId.stringValue).toBe('my-project');
+        expect(body.fields.uploadNumber.integerValue).toBe('4');
+        expect(body.fields.status.stringValue).toBe('active');
+        expect(body.fields.imageCount.integerValue).toBe('10');
+        return { ok: true, status: 200, json: async () => ({}) } as any;
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+
+    // @ts-expect-error - test override
+    globalThis.fetch = fetchMock;
+
+    const svc = createSvc();
+    const upload = await svc.createUpload('my-project', { imageCount: 10 });
+
+    expect(upload.projectId).toBe('my-project');
+    expect(upload.uploadNumber).toBe(4);
+    expect(upload.status).toBe('active');
+    expect(upload.imageCount).toBe(10);
+    expect(upload.id).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledTimes(3); // GET counter + PATCH counter + PATCH upload
+  });
+
+  it('createUpload() initializes counter when it does not exist', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = (init?.method || 'GET').toUpperCase();
+
+      // GET counter — 404
+      if (method === 'GET' && url.includes('/counters/uploads')) {
+        return { ok: false, status: 404, json: async () => ({}) } as any;
+      }
+
+      // PATCH counter (init to 1)
+      if (method === 'PATCH' && url.includes('/counters/uploads')) {
+        const body = JSON.parse(String(init?.body));
+        expect(body.fields.currentUploadNumber.integerValue).toBe('1');
+        return { ok: true, status: 200, json: async () => ({}) } as any;
+      }
+
+      // PATCH upload document
+      if (method === 'PATCH' && url.includes('/documents/projects/my-project/uploads/')) {
+        const body = JSON.parse(String(init?.body));
+        expect(body.fields.uploadNumber.integerValue).toBe('1');
+        return { ok: true, status: 200, json: async () => ({}) } as any;
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+
+    // @ts-expect-error - test override
+    globalThis.fetch = fetchMock;
+
+    const svc = createSvc();
+    const upload = await svc.createUpload('my-project', { imageCount: 5 });
+    expect(upload.uploadNumber).toBe(1);
+  });
+
+  it('getProjectUploads() returns list of uploads via runQuery', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = (init?.method || 'GET').toUpperCase();
+
+      // runQuery uses POST to :runQuery endpoint
+      if (method === 'POST' && url.includes('/projects/my-project:runQuery')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ([
+            {
+              document: {
+                name: 'projects/firebase-proj/databases/(default)/documents/projects/my-project/uploads/u1',
+                fields: {
+                  projectId: { stringValue: 'my-project' },
+                  uploadNumber: { integerValue: '1' },
+                  status: { stringValue: 'completed' },
+                  imageCount: { integerValue: '5' },
+                  createdAt: { timestampValue: '2025-01-01T00:00:00.000Z' },
+                },
+              },
+            },
+          ]),
+        } as any;
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+
+    // @ts-expect-error - test override
+    globalThis.fetch = fetchMock;
+
+    const svc = createSvc();
+    const uploads = await svc.getProjectUploads('my-project');
+
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].projectId).toBe('my-project');
+    expect(uploads[0].uploadNumber).toBe(1);
+    expect(uploads[0].status).toBe('completed');
+  });
+
+  it('updateUploadProcessingStatus() patches the upload doc', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = (init?.method || 'GET').toUpperCase();
+
+      if (method === 'PATCH' && url.includes('/documents/projects/my-project/uploads/u1')) {
+        const body = JSON.parse(String(init?.body));
+        expect(body.fields.processingStatus.stringValue).toBe('completed');
+        return { ok: true, status: 200, json: async () => ({}) } as any;
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+
+    // @ts-expect-error - test override
+    globalThis.fetch = fetchMock;
+
+    const svc = createSvc();
+    await svc.updateUploadProcessingStatus('my-project', 'u1', 'completed' as any);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('deleteUpload() sends DELETE request', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = (init?.method || 'GET').toUpperCase();
+
+      if (method === 'DELETE' && url.includes('/documents/projects/my-project/uploads/u1')) {
+        return { ok: true, status: 200, json: async () => ({}) } as any;
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+
+    // @ts-expect-error - test override
+    globalThis.fetch = fetchMock;
+
+    const svc = createSvc();
+    await svc.deleteUpload('my-project', 'u1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `POST /upload-images/:project` route — creates upload record, returns presigned URL
- Add `POST /upload-images/:project/complete` route — enqueues `UploadQueueMessage`
- Add upload CRUD methods to both Node.js and Worker Firestore implementations
- Add `Upload`, `UploadStatus`, `CreateUploadData` types
- Auto-incrementing upload counter at `projects/{projectId}/counters/uploads`

## Test plan
- [x] `createUpload()` — counter increment + counter initialization (404 case)
- [x] `getProjectUploads()` — runQuery parsing
- [x] `updateUploadProcessingStatus()` — PATCH with processingStatus
- [x] `deleteUpload()` — DELETE request
- [x] All 5 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)