### PR TITLE
feat: carry trace context across the queue

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 // In src/app.ts
 
 import { Hono } from 'hono';
+import { currentTraceContext } from './trace-context.js';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
@@ -402,6 +403,8 @@ app.openapi(uploadRoute, async (c) => {
               buildId,
               zipKey: key,
               timestamp: Date.now(),
+              // Carries the trace across the queue; see src/trace-context.ts.
+              trace: currentTraceContext(),
             });
             console.log(`[INFO] Build queued for processing: buildId=${buildId}`);
           } catch (queueError) {
@@ -722,6 +725,7 @@ app.openapi(metadataUploadRoute, async (c) => {
         buildId: build.id,
         zipKey,
         timestamp: Date.now(),
+        trace: currentTraceContext(),
       });
       queued = true;
     }
@@ -1121,6 +1125,7 @@ app.openapi(imageUploadCompleteRoute, async (c) => {
         uploadId,
         zipKey,
         timestamp: Date.now(),
+        trace: currentTraceContext(),
       });
       queued = true;
     }

--- a/src/entry.worker.ts
+++ b/src/entry.worker.ts
@@ -33,6 +33,8 @@ type Bindings = {
 
   // Sentry configuration
   SENTRY_DSN?: string;
+  /** Optional. Defaults to 1.0 — see below. */
+  SENTRY_TRACES_SAMPLE_RATE?: string;
   SENTRY_ENVIRONMENT?: string;
   SENTRY_RELEASE?: string;
 
@@ -177,9 +179,14 @@ export default Sentry.withSentry(
     environment: env.SENTRY_ENVIRONMENT || env.NODE_ENV || 'production',
     // Release version for tracking deployments and source maps
     release: env.SENTRY_RELEASE,
-    // Capture 100% of errors
-    // For high-traffic workers, consider lowering this in production
-    tracesSampleRate: env.NODE_ENV === 'production' ? 0.1 : 1.0,
+    // Tracing quota is a much smaller budget than errors, so this is a
+    // deliberate rate rather than a default. Sampling at 0.1 meant nine deploys
+    // in ten had no trace — and with a handful of deploys a day, the build
+    // someone is asking about is then almost certainly one of the nine.
+    // Override with SENTRY_TRACES_SAMPLE_RATE if volume grows.
+    tracesSampleRate: env.SENTRY_TRACES_SAMPLE_RATE
+      ? Number(env.SENTRY_TRACES_SAMPLE_RATE)
+      : 1.0,
     // Enable debug mode in non-production environments
     debug: env.NODE_ENV !== 'production',
     // Attach request data to events for better debugging

--- a/src/trace-context.test.ts
+++ b/src/trace-context.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@sentry/cloudflare', () => ({ getTraceData: vi.fn() }));
+
+import * as Sentry from '@sentry/cloudflare';
+import { currentTraceContext } from './trace-context.js';
+
+/**
+ * Cloudflare Queues carry nothing but the message body, so a trace that starts
+ * when a deploy is uploaded ends at `queue.send()` unless the context travels
+ * inside the message. Without it, indexing shows up in Sentry as an unrelated
+ * fragment rather than part of the deploy that caused it.
+ */
+describe('currentTraceContext', () => {
+  const getTraceData = Sentry.getTraceData as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('captures the active trace for the message body', () => {
+    getTraceData.mockReturnValue({
+      'sentry-trace': 'abc123def456-0011223344556677-1',
+      baggage: 'sentry-environment=production',
+    });
+
+    expect(currentTraceContext()).toEqual({
+      sentryTrace: 'abc123def456-0011223344556677-1',
+      baggage: 'sentry-environment=production',
+    });
+  });
+
+  // Absent, not empty. `trace: {}` in a message body reads as "a trace was
+  // attempted and lost", which is a different and more alarming thing than
+  // tracing simply being off.
+  it('returns undefined when there is no active trace', () => {
+    getTraceData.mockReturnValue({});
+    expect(currentTraceContext()).toBeUndefined();
+  });
+
+  it('returns undefined when Sentry returns nothing at all', () => {
+    getTraceData.mockReturnValue(undefined);
+    expect(currentTraceContext()).toBeUndefined();
+  });
+
+  // A deploy that uploaded successfully must still be queued even if telemetry
+  // is broken. Enqueueing is the product; tracing is not.
+  it('never throws when tracing is misconfigured', () => {
+    getTraceData.mockImplementation(() => {
+      throw new Error('Sentry not initialised');
+    });
+
+    expect(() => currentTraceContext()).not.toThrow();
+    expect(currentTraceContext()).toBeUndefined();
+  });
+
+  it('tolerates a trace with no baggage', () => {
+    getTraceData.mockReturnValue({ 'sentry-trace': 'abc-def-1' });
+    expect(currentTraceContext()).toEqual({ sentryTrace: 'abc-def-1', baggage: undefined });
+  });
+});

--- a/src/trace-context.ts
+++ b/src/trace-context.ts
@@ -1,0 +1,41 @@
+import * as Sentry from '@sentry/cloudflare';
+
+/**
+ * Trace context to carry across the queue boundary.
+ *
+ * HTTP hops propagate this in headers automatically. Cloudflare Queues carry
+ * nothing but the message body, so a trace that starts when a deploy is uploaded
+ * ends at `queue.send()` unless the context travels inside the message. Without
+ * it, indexing appears in Sentry as an unrelated fragment rather than part of
+ * the deploy that caused it — and diagnosing a stalled build means
+ * hand-correlating an upload log, a queue log and a Firestore document, which is
+ * exactly what took hours when a credential was revoked.
+ *
+ * The consumer treats every field as optional and falls back to starting a fresh
+ * trace, so messages enqueued before this shipped keep working.
+ */
+export interface QueueTraceContext {
+  sentryTrace?: string;
+  baggage?: string;
+}
+
+/**
+ * Capture the active trace, or `undefined` when there is nothing to propagate.
+ *
+ * Returns `undefined` rather than an empty object so the field is simply absent
+ * from the message when tracing is off — an empty `trace: {}` would suggest a
+ * trace was attempted and lost, which is a different and more alarming thing to
+ * read in a message body.
+ */
+export function currentTraceContext(): QueueTraceContext | undefined {
+  try {
+    const data = Sentry.getTraceData();
+    const sentryTrace = data?.['sentry-trace'];
+    if (!sentryTrace) return undefined;
+    return { sentryTrace, baggage: data?.baggage };
+  } catch {
+    // Never let telemetry break an enqueue. A deploy that uploaded successfully
+    // must still be queued even if tracing is misconfigured.
+    return undefined;
+  }
+}


### PR DESCRIPTION
Producer half of Phase 3 (distributed tracing).

## The gap

HTTP hops propagate trace context in headers automatically. **Cloudflare Queues carry nothing but the body**, so a trace that starts when a deploy is uploaded ended at `queue.send()`. Indexing then appeared in Sentry as an unrelated fragment rather than part of the deploy that caused it — and diagnosing a stalled build meant hand-correlating an upload log, a queue log and a Firestore document, which is exactly what took hours when a credential was revoked.

## The change

All three `queue.send()` sites now attach the active trace.

The consumer (scry-build-processing-service#27) treats the field as **optional** and starts a fresh trace when absent, so messages already in flight and any un-updated producer keep working. **The two services can deploy in either order.**

Two small deliberate choices:

- `currentTraceContext()` returns `undefined` rather than `{}` when there is no trace. `trace: {}` in a message body reads as *"a trace was attempted and lost"*, which is a different and more alarming thing than tracing being off.
- It swallows its own errors. A deploy that uploaded successfully must still be queued even if telemetry is misconfigured — enqueueing is the product, tracing is not.

## Sampling

Was `0.1` in production, so **nine deploys in ten had no trace at all**. With a handful of deploys a day, the build someone asks about is then almost certainly one of the nine. Now `1.0` by default and overridable with `SENTRY_TRACES_SAMPLE_RATE` — a deliberate rate, since tracing quota is a much smaller budget than errors.

## Testing

5 new tests covering the absent-trace, no-baggage and throwing cases. Suite **129/129**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)