### PR TITLE
feat: record storybook_uploaded

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -393,6 +393,16 @@ app.openapi(uploadRoute, async (c) => {
         buildNumber = build.buildNumber;
         console.log(`[INFO] Build created: id=${buildId}, number=${buildNumber}`);
 
+        // Opens the funnel (playbook §5.5): uploaded -> processed -> indexed ->
+        // searched. Not awaited, and trackEvent swallows its own errors — an
+        // upload that succeeded must not fail because analytics did not land.
+        void firestore.trackEvent?.('storybook_uploaded', {
+          projectId: project,
+          buildId,
+          buildNumber,
+          versionId: version,
+        });
+
         // Enqueue build for async processing (LLM inspection, embeddings, vector DB)
         const processingQueue = c.get('processingQueue');
         if (processingQueue && buildId) {

--- a/src/services/firestore/firestore.service.ts
+++ b/src/services/firestore/firestore.service.ts
@@ -20,6 +20,12 @@ export interface FirestoreService {
    * @param data The build data including versionId and zipUrl
    * @returns A promise that resolves to the created Build record
    */
+  /**
+   * Record a product event (playbook §5.5). Optional so the Node implementation
+   * is not forced to grow one; the deployed Worker provides it.
+   */
+  trackEvent?(name: string, props?: Record<string, string | number | boolean | undefined>): Promise<void>;
+
   createBuild(
     projectId: string,
     data: CreateBuildData

--- a/src/services/firestore/firestore.worker.ts
+++ b/src/services/firestore/firestore.worker.ts
@@ -36,6 +36,36 @@ export class FirestoreServiceWorker implements FirestoreService {
    * Creates a new build record with auto-incrementing build number
    * Note: REST API doesn't support true transactions, so we use a simplified approach
    */
+  /**
+   * Record a product event, reusing this service's existing credentials.
+   *
+   * Never throws. An upload that succeeded must not be reported as failed
+   * because an analytics write did not land — the same rule the queue send
+   * already follows, for the same reason.
+   */
+  async trackEvent(name: string, props: Record<string, string | number | boolean | undefined> = {}): Promise<void> {
+    try {
+      const token = await this.getAccessToken();
+      const fields: Record<string, unknown> = {
+        name: { stringValue: name },
+        at: { timestampValue: new Date().toISOString() },
+      };
+      for (const [key, value] of Object.entries(props)) {
+        if (value === undefined) continue;
+        if (typeof value === 'number') fields[key] = { integerValue: String(Math.round(value)) };
+        else if (typeof value === 'boolean') fields[key] = { booleanValue: value };
+        else fields[key] = { stringValue: String(value) };
+      }
+      await fetch(`${this.baseUrl}/events`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fields }),
+      });
+    } catch (e) {
+      console.warn('[EVENTS] Could not record event:', name, e);
+    }
+  }
+
   async createBuild(
     projectId: string,
     data: CreateBuildData


### PR DESCRIPTION
Opens the funnel (playbook §5.5): **uploaded → processed → indexed → searched**. The other three shipped in scry-nextjs#42 and scry-build-processing-service#29, so this completes the observable path from a deploy to a developer finding the component it produced.

`trackEvent` is **optional** on the `FirestoreService` interface. Only the Worker implementation is deployed, and forcing the Node one to grow a method it will never call would be churn for symmetry's sake — call sites use `?.`.

Reuses this service's existing credentials rather than adding a destination. Never throws, never awaited: an upload that succeeded must not be reported as failed because an analytics write did not land — the same rule the queue send already follows.

Suite 129/129, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)