### PR TITLE
fix: emit storybook_uploaded on the route the deployer uses

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -897,6 +897,19 @@ app.openapi(presignedUrlRoute, async (c) => {
       buildNumber = build.buildNumber;
       
       console.log(`[INFO] Build record created for presigned upload: ID=${buildId}, Number=${buildNumber}`);
+
+      // Opens the funnel (playbook §5.5). This is the route the deployer
+      // actually uses — the emitter was first added only to POST /upload, a
+      // direct multipart path nothing in the real flow takes, so the event never
+      // fired despite being deployed. The PMF tracker caught it by noticing
+      // builds that were processed and indexed with no upload recorded: a
+      // contradiction rather than a drop-off.
+      void firestore.trackEvent?.('storybook_uploaded', {
+        projectId: project,
+        buildId,
+        buildNumber,
+        versionId: version,
+      });
     } catch (firestoreError) {
       // Log error but don't fail the presigned URL generation
       console.error('Firestore error (presigned URL succeeded):', firestoreError);


### PR DESCRIPTION
## The bug

The event was added to `POST /upload/:project/:version` — a **direct multipart route**. The deployer uses `POST /presigned-url/:project/:version/:filename`, a different handler.

So the emitter shipped, deployed, and **never fired**. The funnel's first stage read as a 100% drop-off when it was simply unmeasured — the worst kind of analytics bug, because the number looks like a finding.

## How it was caught

The PMF tracker noticed builds that had been **processed and indexed with no upload event recorded**. Those builds did not appear from nowhere, so it reported a contradiction rather than a drop-off:

```
WARNING: builds were processed or indexed with zero upload events recorded.
Those builds did not appear from nowhere, so the upload emitter is probably
not deployed — treat stage 1 as unmeasured, not as "nobody uploaded".
```

That distinction is why this surfaced within hours instead of being read as "nobody deployed this week".

## The fix

The presigned-url handler creates its own build record, so the emit goes alongside it, matching what the other route already does. **Both paths now emit** — whichever a caller takes, the funnel opens.

Suite 129/129, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)